### PR TITLE
[FIX] Use centOS 7 to avoid centOS Stream 8 to break the demo

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM centos:centos7
 MAINTAINER Sander <mail@sandervanvugt.nl>
 
 # Add repo file


### PR DESCRIPTION
Demo uses centOS Stream 8 versión if not specified.
That version breaks the demo from https://learning.oreilly.com/videos/getting-started-with/9780136787709/9780136787709-GSK2_01_02_05/

Using ceontOS 7, solves the issue.
<img width="1094" alt="Captura de Pantalla 2022-02-24 a la(s) 00 36 25" src="https://user-images.githubusercontent.com/43148485/155453325-09ab5d90-a896-4588-b6b1-5c414d1dfc3b.png">


