### PR TITLE
fix nmap

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -4,6 +4,11 @@ MAINTAINER Sander <mail@sandervanvugt.nl>
 # Add repo file
 ADD ./sander.repo /etc/yum.repos.d/
 
+# Bypass GPG key install
+RUN cd /etc/yum.repos.d/
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 # Install cool software
 RUN yum --assumeyes update && \
 yum --assumeyes install bash nmap iproute && \


### PR DESCRIPTION
## Overview
Fixing the current error with Docker install, as it cannot find the URL in mirror list. It should be due to missing GPG key.

```
ENTRYPOINT ["/usr/bin/nmap"]
CMD ["-sn", "172.17.0.0/24"]
[ec2-user@ip-172-31-63-211 dockerfile]$ docker build -t nmap .
Sending build context to Docker daemon  3.072kB
Step 1/6 : FROM centos
latest: Pulling from library/centos
a1d0c7532777: Pull complete
Digest: sha256:a27fd8080b517143cbbbab9dfb7c8571c40d67d534bbdee55bd6c473f432b177
Status: Downloaded newer image for centos:latest
 ---> 5d0da3dc9764
Step 2/6 : MAINTAINER Sander <mail@sandervanvugt.nl>
 ---> Running in 9e9d83a81be5
Removing intermediate container 9e9d83a81be5
 ---> 2e217486f358
Step 3/6 : ADD ./sander.repo /etc/yum.repos.d/
 ---> e04d2fea7e89
Step 4/6 : RUN yum --assumeyes update && yum --assumeyes install bash nmap iproute && yum clean all
 ---> Running in a04c530f77f9
CentOS Linux 8 - AppStream                      203  B/s |  38  B     00:00
Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
The command '/bin/sh -c yum --assumeyes update && yum --assumeyes install bash nmap iproute && yum clean all' returned a non-zero code: 1
```

## What has changed?
Use `vault.centos.org` instead of `yum.repos.d`